### PR TITLE
Update evoBabel.class.php

### DIFF
--- a/assets/snippets/evoBabel/evoBabel.class.php
+++ b/assets/snippets/evoBabel/evoBabel.class.php
@@ -95,8 +95,9 @@ private function checkNumberString($string){
 
 //content functions
 private function saveTV($contentid, $tvid,$tvval){
-    $isset = $this->getValue("SELECT value FROM " . $this->tvs_table . " WHERE contentid=" . $contentid . " AND tmplvarid=" . $tvid . " LIMIT 0, 1");
-    if ($isset) {
+    //$isset = $this->getValue("SELECT value FROM " . $this->tvs_table . " WHERE contentid=" . $contentid . " AND tmplvarid=" . $tvid . " LIMIT 0, 1");
+    $cnt = $this->modx->db->getRecordCount($this->modx->db->select('value', $this->tvs_table, "contentid=".$contentid." AND tmplvarid=".$tvid));
+    if ($cnt) {
         $this->update(array('value'=>$tvval), $this->tvs_table, "contentid=" . $contentid . " AND tmplvarid=" . $tvid);
     } else {
         $this->insert(array('contentid'=>$contentid, 'tmplvarid'=>$tvid, 'value'=>$tvval), $this->tvs_table);
@@ -351,7 +352,8 @@ public function synchTVs($synch_TV, $synch_template, $id){
             while ($tvs = $this->getRow($q)) {
                 foreach ($relations as $k=>$v) {
                     if($v != $id){
-                        $this->copyTVs($id, $v, $synch_TV);
+                        //$this->copyTVs($id, $v, $synch_TV);
+                        $this->copyTVs($id, $v, $tvs['tmplvarid']);
                     }
                 }
             }


### PR DESCRIPTION
1) При значении в TV 0 записи в таблице дублируются до бесконечности. Причина в строке 98

2) Метод copyTVs в строке 354(355) вызывается со списком TV несколько раз в цикле. По логике кода нужно или вызывать без цикла со списком TV, или в цикле по 1 TV.
