### PR TITLE
Update plugin.evoBabel.tpl

### DIFF
--- a/install/assets/plugins/plugin.evoBabel.tpl
+++ b/install/assets/plugins/plugin.evoBabel.tpl
@@ -92,7 +92,7 @@ if (isset($params['rel_tv_id']) && isset($params['lang_template_id'])) {
 
         //фикс для OnWebPageInit на несуществующей странице с несуществующим documentIdentifier
         if (!empty($modx->documentIdentifier)) {
-
+			$langsList='';
             $out = '';
             $langs = array();
             $others = array();//массив других языков (кроме текущего)


### PR DESCRIPTION
В PHP7.3 появляются ругательства на неиницилизированную переменную при выполнении $langsList .= .....
(До версии 7.2 включительно все было хорошо).